### PR TITLE
Revert some permissions related changes

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -28,8 +28,6 @@ LOCAL_AAPT_FLAGS := \
 LOCAL_PACKAGE_NAME := Snap
 LOCAL_PRIVILEGED_MODULE := true
 
-LOCAL_CERTIFICATE := platform
-
 LOCAL_AAPT_FLAGS += --rename-manifest-package org.cyanogenmod.snap
 
 #LOCAL_SDK_VERSION := current

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -7,8 +7,7 @@
         android:minSdkVersion="23"
         android:targetSdkVersion="23" />
 
-    <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS_FULL" />
-    <uses-permission android:name="android.permission.SET_ORIENTATION" />
+
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />


### PR DESCRIPTION
These permissions are not required, so remove them.

Since we no longer declare their use, go back to the default signing
key. This will allow to disable the Snap from the settings.

This reverts the following commits:
53e8b4a71dd0515d922964 ("SnapdragonCamera: Add missing permissions")
bd1d6ea46043e54feca758 ("Snap: Sign with platform key")

Change-Id: I54add5781555f1672918817825ea97c8b51e8ded